### PR TITLE
Topic organisations

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -172,16 +172,19 @@ private
   end
 
   def latest_news_content
-    @latest_news_content ||= begin
-      latest_news_query_params = {
+    topic_query["results"]
+  end
+
+  def topic_query
+    @topic_query ||= begin
+      topic_query_params = {
         count: 5,
         filter_content_purpose_subgroup: "news",
         fields: %w[title description image_url],
-        order: "-public_timestamp"
+        order: "-public_timestamp",
       }.merge(topic_filter(params[:subtopic_slug] || params[:slug]))
 
-      # puts "https://www.gov.uk/api/search.json?#{latest_news_query_params.to_query}"
-      latest_news_content = http_get("https://www.gov.uk/api/search.json?#{latest_news_query_params.to_query}")["results"]
+      http_get("https://www.gov.uk/api/search.json?#{topic_query_params.to_query}")
     end
   end
 

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -23,6 +23,7 @@ class BrowseController < ApplicationController
           image_url: news_result["image_url"] || "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg",
         }
       },
+      organisations: topic_organisations,
       featured: most_popular_content(subtopics),
       subtopics: subtopic_order.map{ |content_id|
 
@@ -175,6 +176,18 @@ private
     topic_query["results"]
   end
 
+  def topic_organisations
+    # Comes from a response looking like: https://www.gov.uk/api/search.json?facet_organisations=20&count=0
+    @topic_organisations ||= begin
+      topic_query["facets"]["organisations"]["options"].map { |org_option|
+        {
+          title: org_option["value"]["title"],
+          url: org_option["value"]["link"],
+        }
+      }
+    end
+  end
+
   def topic_query
     @topic_query ||= begin
       topic_query_params = {
@@ -182,6 +195,7 @@ private
         filter_content_purpose_subgroup: "news",
         fields: %w[title description image_url],
         order: "-public_timestamp",
+        facet_organisations: "20",
       }.merge(topic_filter(params[:subtopic_slug] || params[:slug]))
 
       http_get("https://www.gov.uk/api/search.json?#{topic_query_params.to_query}")


### PR DESCRIPTION
I've added the `organisations` property with the 20 orgs having tagged most to each topic.

It's the second commit where this happens if you're interested in the mechanics :-)


![Screenshot 2020-10-14 at 09 07 27](https://user-images.githubusercontent.com/773037/95961280-b84e7000-0dfc-11eb-997f-b69aad5838b3.png)