### PR TITLE
Build generic content action

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   get "/topic", to: "browse#show_topics"
   get "/topic/:topic_slug", to: "browse#show_specialist_topic"
   get "/topic/:topic_slug/:subtopic_slug", to: "browse#show_specialist_subtopic"
+  get "/generic", to: "browse#show_generic_content"
 end


### PR DESCRIPTION
## What
Add a route, a controller action and several helpers to the api for a `generic` route and action. This will produce data for use in replicating "generic" content.

### Example pages:

- https://www.gov.uk/guidance/intercountry-adoption-information-for-adoption-agencies
- https://www.gov.uk/government/publications/fostering-services-national-minimum-standards

## Why
As part of an effort to consolidate a number of our similar templates into one so that we can use them to test page level navigation.

[Card](https://trello.com/c/qs1U8u5P/493-build-markup-and-routing-for-generic-content-template-in-prototype)

Related to https://github.com/alphagov/explore-prototype-4/pull/19