### PR TITLE
Fix internal links on guides

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -38,7 +38,7 @@ class BrowseController < ApplicationController
   def show_generic_content
     url = "https://www.gov.uk/api/content/#{params[:slug]}"
     content_item = http_get(url).parsed_response
-    details = content_item.dig("details", "body") || content_item.dig("details", "parts")
+    details = content_item.dig("details", "body") || format_parts(content_item.dig("details", "parts"), params[:slug])
     priority_taxons = [
       "634fd193-8039-4a70-a059-919c34ff4bfc",
       "614b2e65-56ac-4f8d-bb9c-d1a14167ba25",
@@ -589,6 +589,15 @@ private
       document["attribute"] = context_phrases[document["document_type"]]
 
       document
+    end
+  end
+
+  def format_parts(parts, slug)
+    parts.map do |part|
+      part["body"] = part["body"].gsub("h2", "h3")
+      part["body"] = part["body"].gsub("#{slug}/", "#")
+
+      part
     end
   end
 end


### PR DESCRIPTION
## What/Why
To more easily prototype page level nav, we've converted each section within a guide from individual pages to content on a single page with headings. This however has messed up navigation between sections. This replaces links to those intended separate pages to hash characters so that they're now anchor links instead of links to other pages that currently don't go anywhere.

Also whilst we're here, this converts h2s in the body content of sections to h3s for accessibility reasons.