### PR TITLE
Pass related topics data to browse suptopic pages

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -244,6 +244,8 @@ private
       payload[:related_topics] = related_topics(content_item)
     end
 
+    payload[:detailed_guidance] = content_item.dig("links", "related_topics")
+
     render json: payload
   end
 


### PR DESCRIPTION
## What/Why
Add data for detailed guidance on browse suptopic pages so that during the research, users are able to more easily switch between mainstream and whitehall content.

Test page: https://www.gov.uk/browse/housing-local-services/planning-permission

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-10-18 at 07 51 17](https://user-images.githubusercontent.com/64783893/137682427-f293cf3c-1a62-452a-b8d7-6908ee79a779.png) | ![Screenshot 2021-10-18 at 07 50 35](https://user-images.githubusercontent.com/64783893/137682341-13581309-ee0c-487c-ad0a-384381f13023.png) | 