### PR TITLE
Update calculation on split guides contents list

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -522,7 +522,7 @@ private
         text: part["title"],
       }
 
-      is_active_page = part["slug"] == slug
+      is_active_page = (part["slug"] == slug || (base_path == slug && part["slug"] == "#{base_path}/overview"))
 
       contents_list_item[:slug] = is_active_page ? false : "#{base_path}/#{part["slug"]}"
       contents_list_item[:is_current_page] = is_active_page


### PR DESCRIPTION
## What/Why
Updates the calculation for producing a contents list for split guides to fix an issue when you go to the route URL for a guide and the overview contents link, which is the default content part which loads, isn't highlighted a has a dodgy href.

Test page https://www.gov.uk/party-walls-building-works
Related to https://github.com/alphagov/explore-prototype-4/pull/51