### PR TITLE
Remove taxon rules from breadcrumb calculations

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -435,20 +435,18 @@ private
   end
 
   def breadcrumb_content(content_item, is_html_pub = false)
-    return false if !content_item
+    return [] if !content_item
 
     if is_html_pub
-      breadcrumbs = []
       parent_content_item = http_get("https://www.gov.uk#{content_item.dig("links", "parent", 0, "api_path")}").parsed_response
-
       breadcrumb_content(parent_content_item)
     else
       if content_item.dig("links", "parent")
         breadcrumbs_by_parent(content_item.dig("links", "parent", 0))
       elsif content_item.dig("links", "topics")
         content_item.dig("links", "topics")
-      elsif content_item.dig("links", "taxons")
-        breadcrumbs_by_taxon(content_item.dig("links", "taxons", 0))
+      else
+        []
       end
     end
   end
@@ -459,17 +457,6 @@ private
 
     if potential_parent
       (breadcrumbs << breadcrumbs_by_parent(potential_parent)).flatten!
-    else
-      breadcrumbs
-    end
-  end
-
-  def breadcrumbs_by_taxon(taxon)
-    breadcrumbs = [taxon]
-    potential_parent_taxon = taxon.dig("links", "parent_taxons", 0)
-
-    if potential_parent_taxon
-      (breadcrumbs << breadcrumbs_by_taxon(potential_parent_taxon)).flatten!
     else
       breadcrumbs
     end


### PR DESCRIPTION
## What
Removes taxons from breadcrumb calculations completely.

## Why
This is in line with the new rules on removing taxons from our breadcrumbs. The proposal from Kati on how to handle this in the prototype for now:

>We'll remove taxonomy topics from the breadcrumb.
Instead of the taxonomy topic we'll show specialist topic if the content item is tagged to a specialist topic page.
>
>If the content item is not tagged to a specialist topic page, then the only thing in the breadcrumb will be 'home'.
>
>This means there is no need to hardcode any new associations for the content item if they don't already exist.
>
>In some ways it's not great as there will then be pages where we will miss the breadcrumb so perhaps less opportunities to test that,  but at least we're not messing with the tagging and journeys. Llke the example you mentioned Owen that it can be tricky for the user to find the content page they were on if they go to a specialist topic page and the page is not listed there because we've hardcoded a link to the specialist topic page in the breadcrumb. That kind of thing feels messy.

### Test pages
- https://explore-prot-main-1t1ojulm6nzn.herokuapp.com/government/consultations/domestic-smoke-and-carbon-monoxide-alarms/domestic-smoke-and-carbon-monoxide-alarms-proposals-to-extend-regulations
- https://explore-prot-main-1t1ojulm6nzn.herokuapp.com/government/publications/building-regulations-advisory-committee-golden-thread-report/building-regulations-advisory-committee-golden-thread-report