### PR TITLE
Fix missed updates to functionality related to generic content

### DIFF
--- a/app/controllers/generic_content_controller.rb
+++ b/app/controllers/generic_content_controller.rb
@@ -18,7 +18,6 @@ class GenericContentController < ApplicationController
       priority_taxons.include?(taxon["content_id"])
     end
     is_html_pub = params[:htmlpub] == "true"
-    collection_documents = content_item["document_type"] == "document_collection" && format_collection_documents(content_item.dig("links", "documents"))
 
     if !details && content_item.dig("details", "parts")
       details = format_parts(content_item.dig("details", "parts"), content_item["base_path"], params[:slug])
@@ -60,12 +59,11 @@ class GenericContentController < ApplicationController
       payload[:context] = context_phrases[payload[:part_of_parent]["document_type"]]
     end
 
-    if collection_documents
-      payload[:main_document] = collection_documents[0]
-      payload[:archived_documents] = collection_documents.drop(1)
+    if content_item["schema_name"] == "document_collection"
+      payload[:document_collections] = format_collection_documents(content_item.dig("links", "documents"), content_item.dig("details", "collection_groups"))
     end
 
-    if content_item["document_type"] == "guide"
+    if content_item["schema_name"] == "guide"
       payload[:is_mainstream_guide] = true
     end
 
@@ -111,7 +109,7 @@ private
 
   def display_date_and_time(timestamp, rollback_midnight: false)
     return false unless timestamp.present?
-    
+
     time = Time.zone.parse(timestamp)
     date_format = "%-e %B %Y"
     time_format = "%l:%M%P"
@@ -261,15 +259,44 @@ private
     }
   end
 
-  def format_collection_documents(documents)
-    return [] unless documents.present?
+  def format_collection_documents(documents, groupings)
+    return [] unless documents.present? && groupings.present?
 
-    documents.map do |document|
-      document["formatted_date"] = display_date(document["public_updated_at"])
-      document["attribute"] = context_phrases[document["document_type"]]
+    filtered_groups = []
 
-      document
+    groupings.each do |group|
+      unless group["documents"].empty?
+        filtered_group = {
+          title: group["title"],
+          slug: group["title"].gsub(" ", "-").downcase,
+          body: group["body"],
+        }
+
+        filtered_documents = []
+
+        group["documents"].each do |doc_id|
+          selected_doc = documents.filter do |document|
+            document["content_id"] == doc_id
+          end
+
+          if selected_doc.present?
+            selected_doc = selected_doc[0]
+            selected_doc["formatted_date"] = display_date(selected_doc["public_updated_at"])
+            selected_doc["attribute"] = context_phrases[selected_doc["document_type"]]
+
+            filtered_documents << selected_doc
+          end
+        end
+
+        filtered_group[:documents] = filtered_documents
+
+        unless filtered_documents.empty?
+          filtered_groups << filtered_group
+        end
+      end
     end
+
+    filtered_groups
   end
 
   def format_parts(parts, base_path, slug)
@@ -278,8 +305,6 @@ private
     correct_part = parts.filter do |part|
       part["slug"] == filter
     end
-
-    puts stripped_slug
 
     correct_part.map do |part|
       part["slug"] = "#{base_path}/#{part["slug"]}"


### PR DESCRIPTION
## What/Why
During the split between browse and generic, a few of the most recent updates got lost in rebase hell. This amends things so they're fully up to date.

This also fixes https://trello.com/c/Emx8kCXm/600-documents-not-appearing-on-document-collections-page

![explore-prot-main-1t1ojulm6nzn herokuapp com_government_collections_approved-documents](https://user-images.githubusercontent.com/424772/138473475-10f1885f-349a-4861-8681-cdaacbfaa20e.png)


