### PR TITLE
Strip links that explicitly route users to gov.uk

### DIFF
--- a/app/controllers/generic_content_controller.rb
+++ b/app/controllers/generic_content_controller.rb
@@ -32,7 +32,7 @@ class GenericContentController < ApplicationController
       closing_date_time: content_item.dig("details", "closing_date"),
       closing_date_time_display: display_date_and_time(content_item.dig("details", "closing_date"), rollback_midnight: true),
       intro: content_item.dig("details", "introduction"),
-      details: details,
+      details: strip_govuk_links(details),
       documents: content_item.dig("details", "documents"),
       show_form: content_item["schema_name"] == "local_transaction",
       need_to_know: content_item.dig("details", "need_to_know"),
@@ -332,5 +332,16 @@ private
     end
 
     formatted
+  end
+
+  def strip_govuk_links(details)
+    if details.kind_of?(Array)
+      details.map do |item|
+        item["body"] = strip_govuk_links(item["body"])
+        item
+      end
+    else
+      details.gsub(/(https?:\/\/(www\.)?gov\.uk(\/)?)/, "/")
+    end
   end
 end


### PR DESCRIPTION
## What
Looks for URLs in content that explicitly state either www.gov.uk or gov.uk and replace them with `/`.

## Why
For the upcoming round of research, we want to avoid the possibility of users accidentally moving off of the prototype due to links that are formatted as full gov.uk URLs.

## For testing
Test page: https://explore-prot-main-1t1ojulm6nzn.herokuapp.com/government/consultations/domestic-smoke-and-carbon-monoxide-alarms/domestic-smoke-and-carbon-monoxide-alarms-proposals-to-extend-regulations

Live page: https://www.gov.uk/government/consultations/domestic-smoke-and-carbon-monoxide-alarms/domestic-smoke-and-carbon-monoxide-alarms-proposals-to-extend-regulations

To test: There's a link in the content of this page that goes to `gov.uk/mhclg`. This should like specifically to `/mhclg` not `http://www.gov.uk/mhclg` as it does on live.